### PR TITLE
Switch rate limit rules from count to block

### DIFF
--- a/awswafwebaclrules.ts
+++ b/awswafwebaclrules.ts
@@ -11,8 +11,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesPublicRoutes',
       priority: 100,
-      overrideAction: {
-        none: {},
+      action: {
+        block: {}
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -67,8 +67,8 @@ export const rateBasedRules: WafRule[] = [
           }
         }
       },
-      overrideAction: {
-        none: {},
+      action: {
+        block: {}
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -82,8 +82,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesPublicAPIRoutes',
       priority: 300,
-      overrideAction: {
-        none: {},
+      action: {
+        block: {}
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -143,8 +143,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesQualtricsApi',
       priority: 400,
-      overrideAction: {
-        none: {},
+      action: {
+        block: {}
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,

--- a/awswafwebaclrules.ts
+++ b/awswafwebaclrules.ts
@@ -11,8 +11,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesPublicRoutes',
       priority: 100,
-      action: {
-        count: {}
+      overrideAction: {
+        none: {},
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -67,8 +67,8 @@ export const rateBasedRules: WafRule[] = [
           }
         }
       },
-      action: {
-        count: {}
+      overrideAction: {
+        none: {},
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -82,8 +82,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesPublicAPIRoutes',
       priority: 300,
-      action: {
-        count: {}
+      overrideAction: {
+        none: {},
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,
@@ -143,8 +143,8 @@ export const rateBasedRules: WafRule[] = [
     rule: {
       name: 'MyEv-RateBasedRulesQualtricsApi',
       priority: 400,
-      action: {
-        count: {}
+      overrideAction: {
+        none: {},
       },
       visibilityConfig: {
         sampledRequestsEnabled: true,


### PR DESCRIPTION
I checked on the WAF's new rate limit rules and they don't seem to be blocking users incorrectly. I'll probably leave them on COUNT for a couple more days, but prepping this PR in advance of merge to set them to block.